### PR TITLE
Update GH Actions Runner OS

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -10,6 +10,7 @@ jobs:
     name: ${{ matrix.os }} Build
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-2016, macOS-10.14]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v1
 
@@ -20,7 +20,7 @@ jobs:
           node-version: '10.x'
 
       - name: Setup MSBuild.exe
-        if: matrix.os == 'windows-2016'
+        if: matrix.os == 'windows-latest'
         uses: warrenbuckley/Setup-MSBuild@v1
 
       - name: Dependencies


### PR DESCRIPTION
Updating to latest since GitHub has [deprecated](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idruns-on) `windows-2016` and `macOS-10.14`. We don't know when they will stop these, probably by end of this year. 

Also this PR lets the other matrix builds run, even when some of them fail. By default it is set to cancel the remaining jobs. This will help in tracking down platform related issues if any may arise in future